### PR TITLE
docs(repository): Synchronize repository labels

### DIFF
--- a/.github/workflows/github.labels.yml
+++ b/.github/workflows/github.labels.yml
@@ -1,0 +1,17 @@
+name: Create Default Labels
+on:
+  issues:
+  push:
+    paths:
+      - .github/workflows/github.labels.yml
+      - .github/labels.json
+
+jobs:
+  labels:
+    name: DefaultLabelsActions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@1.0.0
+      - uses: lannonbr/issue-label-manager-action@2.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Synchronize the labels in this repository with authoritative source.

Standardize the github labels to facilitate automation across all the repositories. This is done as part of some testings work for developing tooling that verifies constraints on datasets (git repos), and if possible it will resolve the invalid constraint.