### PR TITLE
docs(repository): Sync repository metadata

### DIFF
--- a/.repository/index.json
+++ b/.repository/index.json
@@ -1,6 +1,6 @@
 {
   "slug": "vagrant-desktop",
-  "namespace": "jrbeverly",
+  "namespace": "jrbeverly-devenv",
   "status": "archived",
   "icon": "icon.svg",
   "license": {


### PR DESCRIPTION
Sync the repository metadata in code, from the github data.

Standardize the github data on topics, taglines and other properties into a repository definition file. For now this can be json instead of YAML, as that is easier to get started with. Later work can be done to convert this to a YAML format.